### PR TITLE
Handle missing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ x3x2ComparisonScores = s.batch_compare(x3,x2)
 *****
 *Missing data:*
 
-Missing data is supported.  Input values of `numpy.nan` will not affect normalization and will be converted to the `-` character during alphabetization. When comparing two strings containing the `-` character, the distance contribution for any such characters will be 0.
+Missing data is supported.  Input values of `numpy.nan` will not affect normalization and will be converted to the `-` character during alphabetization. When comparing two strings containing the `-` character, the distance contribution for any such characters will be 0. For example, comparing `aa-a` to `a-aa` will result in a distance of 0.  As another example, comparing `abc` to `d-f` will be the same as comparing `ac` to `df`.
 
 *****
 *Note:*

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ x3x2ComparisonScores = s.batch_compare(x3,x2)
 ```
 
 *****
+*Missing data:*
+
+Missing data is supported.  Input values of `numpy.nan` will not affect normalization and will be converted to the `-` character during alphabetization. When comparing two strings containing the `-` character, the distance contribution for any such characters will be 0.
+
+*****
 *Note:*
 
 If you haven't generated the strings through the same SAX object, the scaling

--- a/saxpy.py
+++ b/saxpy.py
@@ -66,9 +66,14 @@ class SAX(object):
         of the original array.
         """
         X = np.asanyarray(x)
-        if X.std() < self.eps:
-            return [0 for entry in X]
-        return (X-X.mean())/X.std()
+        if np.nanstd(X) < self.eps:
+            res = []
+            for entry in X:
+                if not np.isnan(entry):
+                    res.append(0)
+                else:
+                    res.append(np.nan)
+        return (X - np.nanmean(X)) / np.nanstd(X)
 
     def to_PAA(self, x):
         """
@@ -100,6 +105,10 @@ class SAX(object):
         for i in range(0, len(paaX)):
             letterFound = False
             for j in range(0, len(self.beta)):
+                if np.isnan(paaX[i]):
+                    alphabetizedX += '-'
+                    letterFound = True
+                    break
                 if paaX[i] < self.beta[j]:
                     alphabetizedX += chr(self.aOffset + j)
                     letterFound = True
@@ -119,7 +128,8 @@ class SAX(object):
         list_letters_b = [x for x in sB]
         mindist = 0.0
         for i in range(0, len(list_letters_a)):
-            mindist += self.compare_letters(list_letters_a[i], list_letters_b[i])**2
+            if list_letters_a[i] is not '-' and list_letters_b[i] is not '-':
+                mindist += self.compare_letters(list_letters_a[i], list_letters_b[i])**2
         mindist = self.scalingFactor* np.sqrt(mindist)
         return mindist
 

--- a/tests/test_saxpy.py
+++ b/tests/test_saxpy.py
@@ -1,4 +1,5 @@
 from saxpy import SAX
+import numpy as np
 
 class TestSAX(object):
     def setUp(self):
@@ -11,10 +12,20 @@ class TestSAX(object):
         (letters, indices) = self.sax.to_letter_rep(arr)
         assert letters == 'eacccc'
 
+    def test_to_letter_rep_missing(self):
+        arr = [7,1,4,4,np.nan,4]
+        (letters, indices) = self.sax.to_letter_rep(arr)
+        assert letters == 'eacc-c'
+
     def test_long_to_letter_rep(self):
         long_arr = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,6,6,6,6,10,100]
         (letters, indices) = self.sax.to_letter_rep(long_arr)
         assert letters == 'bbbbce'
+
+    def test_long_to_letter_rep_missing(self):
+        long_arr = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,np.nan,1,1,6,6,6,6,10,100]
+        (letters, indices) = self.sax.to_letter_rep(long_arr)
+        assert letters == 'bbb-ce'
 
     def test_compare_strings(self):
         base_string = 'aaabbc'
@@ -23,3 +34,14 @@ class TestSAX(object):
         similar_score = self.sax.compare_strings(base_string, similar_string)
         dissimilar_score = self.sax.compare_strings(base_string, dissimilar_string)
         assert similar_score < dissimilar_score
+
+    def test_compare_strings_missing(self):
+        assert self.sax.compare_strings('a-b-c-', 'b-c-d-') == 0
+
+    def test_normalize_missing(self):
+        # two arrays which should normalize to the same result
+        # except one should contain a nan value in place of the input nan value
+        incomplete_arr_res = self.sax.normalize([1,0,0,0,0,1,np.nan])
+        complete_arr_res = self.sax.normalize([1,0,0,0,0,1])
+        assert np.array_equal(incomplete_arr_res[:-1], complete_arr_res)
+        assert np.isnan(incomplete_arr_res[-1])


### PR DESCRIPTION
This branch allows the use of missing data, represented as `numpy.nan`

- uses numpy functions to normalize data, effectively ignoring missing values for mean and standard deviation calculations
- uses the character `'-'` to encode missing values during alphabetization
- skips comparisons to `'-'` characters during distance calculations